### PR TITLE
Added support for java runtime

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,3 +3,4 @@
 Add your name in the given format.
 
 * [Alok Kumar Singh](https://github.com/akstron)
+* [Dennis Thomas](https://github.com/DNA5769)

--- a/src/Config/Config.py
+++ b/src/Config/Config.py
@@ -7,7 +7,7 @@ from ..Runner.exceptions.UnsupportedLanguage import UnsupportedLanguage
     Class to manage config related commands
 '''
 class Config():
-    supported_lang = ['cpp', 'python']
+    supported_lang = ['cpp', 'python', 'java']
 
     def __init__(self) -> None:
         self.config_file_path = self.get_config_path()

--- a/src/Problem/ProblemManager.py
+++ b/src/Problem/ProblemManager.py
@@ -40,7 +40,10 @@ class ProblemManager:
         if lang not in ext_map:
             raise UnsupportedLanguage(lang)
 
-        code_file_path = Path(dir, f'code.{ext_map[lang]}')
+        if lang == 'java':
+            code_file_path = Path(dir, 'Code.java')
+        else:
+            code_file_path = Path(dir, f'code.{ext_map[lang]}')
         
         ''' 
             'w' with overwrite the file, even if we don't write anything 

--- a/src/Runner/mapper.py
+++ b/src/Runner/mapper.py
@@ -2,14 +2,16 @@
     Mappers to map functions and extensions to their respective handlers
 '''
 
-from .runner import run_cpp_code, run_python_code
+from .runner import run_cpp_code, run_java_code, run_python_code
 
 runner_map = {
     'cpp' : run_cpp_code,
-    'python' : run_python_code
+    'python' : run_python_code,
+    'java' : run_java_code
 }
 
 ext_map = {
     'cpp' : 'cpp', 
-    'python' : 'py'
+    'python' : 'py',
+    'java' : 'java',
 }

--- a/src/Runner/runner.py
+++ b/src/Runner/runner.py
@@ -3,6 +3,7 @@ import click
 from .exceptions.CodeError import CodeError
 from .TestValidator import TestValidator
 from .runners.CppRunner import CppRunner
+from .runners.JavaRunner import JavaRunner
 from .runners.PythonRunner import PythonRunner
 
 # dest is the directory path
@@ -10,6 +11,24 @@ def run_cpp_code(dest, custom):
     try:
         code_file = Path(dest, 'code.cpp')
         runner = CppRunner(dest, code_file)
+
+        if custom:
+            runner.run_on_custom()
+        else :
+            runner.run_on_test_files()
+            # validate_output(dest)
+            validator = TestValidator(dest)
+            validator.validate_output()
+        
+    except CodeError as e:
+        click.echo(e)
+
+    except Exception as e:
+        click.echo(e)
+
+def run_java_code(dest, custom):
+    try:
+        runner = JavaRunner(dest, 'Code.java')
 
         if custom:
             runner.run_on_custom()

--- a/src/Runner/runners/JavaRunner.py
+++ b/src/Runner/runners/JavaRunner.py
@@ -15,7 +15,9 @@ class JavaRunner(Runner):
         self.exec_file = Path(dest, code_file[:-5])
 
     def __compile_code(self):
-        return subprocess.run(['javac', self.code_file], capture_output=True, text=True)
+        compile_result = subprocess.run(['javac', self.code_file], capture_output=True, text=True)
+        if compile_result.returncode != 0:
+            raise CodeError(compile_result.stderr, 'compile error', compile_result.returncode)
 
     def __execute_code(self, stdin = None):
         return subprocess.run(['java', self.exec_file], capture_output=True, text=True, stdin=stdin)

--- a/src/Runner/runners/JavaRunner.py
+++ b/src/Runner/runners/JavaRunner.py
@@ -1,0 +1,47 @@
+import os
+import click
+import subprocess
+from pathlib import Path
+from .Runner import Runner
+from ..exceptions.CodeError import CodeError
+
+'''
+    Class to handle Java code execution
+'''
+class JavaRunner(Runner):
+    def __init__(self, dest, code_file) -> None:
+        super().__init__(dest, Path(dest, code_file))
+        self.__compile_code()
+        self.exec_file = Path(dest, code_file[:-5])
+
+    def __compile_code(self):
+        return subprocess.run(['javac', self.code_file], capture_output=True, text=True)
+
+    def __execute_code(self, stdin = None):
+        return subprocess.run(['java', self.exec_file], capture_output=True, text=True, stdin=stdin)
+
+    def run_on_test_files(self):
+        current_dir = os.listdir(self.dest)
+
+        for file_name in current_dir:
+            if len(file_name) >= 5:
+                if file_name[:5] == 'input' and file_name[-4:] == '.txt':
+                    input_file_name = file_name
+                    
+                    input_file_path = Path(input_file_name)
+                    with open(input_file_path, 'r') as content:   
+                        # Run executable file with sample input files
+                        exec_result = self.__execute_code(content)
+
+                        if exec_result.returncode != 0:
+                            raise CodeError(exec_result.stderr, 'runtime error', exec_result.returncode)
+
+                        output_file_path = Path(f'output{file_name[5:]}')
+
+                        # Write output obtained from to output_file
+                        with open(output_file_path, 'w') as output_file:
+                            output_file.write(exec_result.stdout.strip()) 
+
+    def run_on_custom(self):
+        exec_result = self.__execute_code()
+        click.echo(exec_result.stdout)


### PR DESCRIPTION
Fixes #1 

Firstly I made java a supported language by editing `Config.py`
```py
# src/Config/Config.py
class Config():
    supported_lang = ['cpp', 'python', 'java']
    ...
```

I then wrote the code for creating the code file in `ProblemManager.py`. Had to do this separately since I wanted to capitalise the first letter to follow convention
```py
# src/Problem/ProblemManager.py
        ...
        if lang == 'java':
            code_file_path = Path(dir, 'Code.java')
        else:
            code_file_path = Path(dir, f'code.{ext_map[lang]}')
        ...
```

Added mappers for java in `mapper.py`
```py
# src/Runner/mapper.py
runner_map = {
    'cpp' : run_cpp_code,
    'python' : run_python_code,
    'java' : run_java_code
}

ext_map = {
    'cpp' : 'cpp', 
    'python' : 'py',
    'java' : 'java',
}
```

I wrote `run_java_code` function in `runner.py`. Tbh I just copied `run_cpp_code` 😋 

I also wrote `JavaRunner` class in `JavaRunner.py`. This too is very similar too `CppRunner.py` 😋😋. However I did add a compile error check to JavaRunner *(I think we should do this for CppRunner as well)*
```py
# src/Runner/runners/JavaRunner.py
...
    def __compile_code(self):
        compile_result = subprocess.run(['javac', self.code_file], capture_output=True, text=True)
        if compile_result.returncode != 0:
            raise CodeError(compile_result.stderr, 'compile error', compile_result.returncode)
...
```