### PR TITLE
Edited COMMANDS.md

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -47,7 +47,7 @@
 
 *   Stop a test session using: 
     ```
-    ecp test stop
+    ecp test end
     ```
 
 *   Get remaining time duration in a test using: 

--- a/src/Cli/config.py
+++ b/src/Cli/config.py
@@ -33,5 +33,12 @@ def set_temp(path):
     except Exception as e:
         click.echo(e)
 
+@click.command()
+def get_lang():
+    config = Config()
+    lang = config.get_lang()
+    click.echo(click.style('Current Enviroment language : ' + lang))
+
+config.add_command(get_lang)
 config.add_command(set_lang)
 config.add_command(set_temp)


### PR DESCRIPTION
The command to end test was described wrongly in COMMANDS.md, and needed updating because not everyone will go through "ecp test --help" to get what is wrong in executing the command "ecp test stop" given in COMMANDS.md.
![image](https://user-images.githubusercontent.com/81406743/193452107-ee382507-5fee-45b3-8307-f19a117d35f1.png)
![image](https://user-images.githubusercontent.com/81406743/193452168-131b81d6-ca25-4f16-b2bc-6f7c4d7bd903.png)

