### PR TITLE
Fixes issue #2 and miscellaneous issue in COMMANDS.md

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -37,6 +37,11 @@
     ```
     `<dest>` is the absolute template file path
 
+*   Get current runtime environment language using:
+    ```
+    ecp config get-lang
+    ```
+
 *   Start a test session using:
     ```
     ecp test start <time>

--- a/src/Cli/config.py
+++ b/src/Cli/config.py
@@ -33,5 +33,12 @@ def set_temp(path):
     except Exception as e:
         click.echo(e)
 
+@click.command()
+def get_lang():
+    config = Config()
+    lang = config.get_lang()
+    click.echo(click.style('Current Enviroment language : ' + lang))
+
+config.add_command(get_lang)
 config.add_command(set_lang)
 config.add_command(set_temp)


### PR DESCRIPTION
# Issue #2 
Added command 'ecp config get-lang' to get the current runtime environment language
``` python
@click.command()
def get_lang():
    config = Config()
    lang = config.get_lang()
    click.echo(click.style('Current Enviroment language : ' + lang))
```
### Miscellaneous Issue
A command to end test was given wrongly in COMMANDS.md
![image](https://user-images.githubusercontent.com/81406743/194018342-04786c5d-5267-433a-8e5c-bc06f2a5f4bc.png)

![image](https://user-images.githubusercontent.com/81406743/194018591-00c7e040-9a9d-406c-a057-c5e603ca359e.png)
which is now corrected.