### PR TITLE
Fixes Issue #7

### DIFF
--- a/src/Cli/config.py
+++ b/src/Cli/config.py
@@ -28,8 +28,11 @@ def set_lang(lang):
 def set_temp(path):
     try:
         config = Config()
-        config.set_template(path)
-        click.echo(click.style('Template path set', fg='green'))
+        if config.is_text_file(path):
+            config.set_template(path)
+            click.echo(click.style('Template path set', fg='green'))
+        else:
+            click.echo(click.style('Template must be a text file', fg='red'))
     except Exception as e:
         click.echo(e)
 

--- a/src/Config/Config.py
+++ b/src/Config/Config.py
@@ -54,3 +54,11 @@ class Config():
             config = json.load(config_file)
         
         return config['template']
+
+    def is_text_file(self, file_name):
+        try:
+            with open(file_name, 'tr') as check_file:
+                check_file.read()
+                return True
+        except:
+            return False


### PR DESCRIPTION
Added a function as utility in /src/Config/Config.py that only reads text files, throws error otherwise
``` python
  def is_text_file(self, file_name):
      try:
          with open(file_name, 'tr') as check_file:
              check_file.read()
              return True
      except:
          return False
```
Used this function as a check for text files and updated set_temp function in /src/Cli/config.py for the same
``` python
@click.command()
@click.argument('path', type=str)
def set_temp(path):
    try:
        config = Config()
        if config.is_text_file(path):
            config.set_template(path)
            click.echo(click.style('Template path set', fg='green'))
        else:
            click.echo(click.style('Template must be a text file', fg='red'))
    except Exception as e:
        click.echo(e)
```